### PR TITLE
Run PR CI on pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,8 @@ on:
   push:
   release:
     types: [published]
-  pull_request_target:
+  # plain pull_request: fork runs get no secrets and a read-only token
+  pull_request:
     branches: [ "main" ]
 permissions:
   contents: write


### PR DESCRIPTION
go.yml ran fork PRs under `pull_request_target` with `permissions: contents: write`, which executes untrusted PR code with a privileged `GITHUB_TOKEN` persisted by checkout. The PR path (build job) references no secrets, and the publish job that uses `viam_key_id`/`viam_key_value` only runs on `release` events — so plain `pull_request` does the same work while GitHub withholds secrets and issues a read-only token for fork runs. The `event_name` checkout conditionals already handle `pull_request` via the default merge-ref checkout.

Part of an org-wide sweep of `pull_request_target` use (same change as viamrobotics/viam-python-sdk#1246).

🤖 Generated with [Claude Code](https://claude.com/claude-code)